### PR TITLE
add libffi-dev to ubuntu_debian_dependancies.sh

### DIFF
--- a/ubuntu_debian_dependancies.sh
+++ b/ubuntu_debian_dependancies.sh
@@ -6,6 +6,6 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
 sudo apt-get update
-sudo apt-get install golang yarn nodejs ruby ruby-dev build-essential rpm
+sudo apt-get install golang yarn nodejs ruby ruby-dev build-essential rpm libffi-dev
 
 sudo gem install fpm


### PR DESCRIPTION
this is required for building ruby's fpm